### PR TITLE
Add own class to replace deprecated `descartes.PolygonPatch`

### DIFF
--- a/sregion/__init__.py
+++ b/sregion/__init__.py
@@ -1,4 +1,4 @@
-from .sregion import SRegion
+from .sregion import SRegion, patch_from_polygon
 
 try:
     from .version import __version__

--- a/sregion/sregion.py
+++ b/sregion/sregion.py
@@ -424,6 +424,20 @@ class PatchPolygon:
 def patch_from_polygon(polygon, **kwargs):
     """
     Generate the Path object from `PatchPolygon`
+    
+    Parameters
+    ----------
+    polygon : `shapely.geometry.Polygon`
+        Input polygon object
+    
+    kwargs : dict
+        Keywords to pass when generating the ``patch``
+    
+    Returns
+    -------
+    patch : `from matplotlib.patches.PathPatch`
+        The patch that can be added to a `matplotlib` figure
+    
     """
     obj = PatchPolygon(polygon, **kwargs)
     return obj._patch

--- a/sregion/tests/test_sregion.py
+++ b/sregion/tests/test_sregion.py
@@ -1,7 +1,7 @@
 import numpy as np
 import astropy.units as u
 
-from .. import SRegion
+from .. import SRegion, patch_from_polygon
 
 
 def test_sregion():
@@ -183,3 +183,12 @@ LONPOLE =                180.0
     assert(np.allclose(sw.sky_area(unit=u.deg**2), pixel_area*u.deg**2))
     assert(np.allclose(sw.sky_area(unit=u.arcmin**2),
                        (pixel_area*u.deg**2).to(u.arcmin**2)))
+
+
+def test_patch():
+    """
+    Test patch function
+    """
+    
+    circ = SRegion('CIRCLE 5. 5. 1', ncircle=256)
+    patch = patch_from_polygon(circ.shapely[0], fc='k')


### PR DESCRIPTION
Implement a `sregion.PatchPolygon` class and calling function `sregion.patch_from_polygon` to replace `descartes.PolygonPatch`, where the latter appears to be broken for `shapely>=2.0`.

