### PR TITLE
Strip some characters from STC-S string definitions

### DIFF
--- a/sregion/sregion.py
+++ b/sregion/sregion.py
@@ -78,7 +78,7 @@ def _wrap_xy(xy):
     return wxy
 
 
-def _parse_sregion(sregion, ncircle=32, **kwargs):
+def _parse_sregion(sregion, ncircle=32, verbose=False, **kwargs):
     """
     Parse an S_REGION string with CIRCLE or POLYGON
 
@@ -97,7 +97,22 @@ def _parse_sregion(sregion, ncircle=32, **kwargs):
         decoded = sregion.decode('utf-8').strip().upper()
     else:
         decoded = sregion.strip().upper()
-
+    
+    # Strip out prefix for some STS-C regions
+    for strip_string in ['UNION','ICRS','FK5', 'IMAGE', 'WORLD']:
+        if (strip_string in decoded) & verbose:
+            print('Strip {0} from {1}'.format(strip_string, sregion))
+            
+        decoded = decoded.replace(strip_string, '')
+    
+    decoded = decoded.strip()
+    if decoded.startswith('('):
+        decoded = decoded[1:]
+    
+    if decoded.endswith(')'):
+        decoded = decoded[:-1]
+    
+    decoded = decoded.strip()
     polyspl = decoded.replace('POLYGON', 'xxx').replace('CIRCLE', 'xxx')
     polyspl = polyspl.split('xxx')
 

--- a/sregion/tests/test_sregion.py
+++ b/sregion/tests/test_sregion.py
@@ -125,6 +125,20 @@ def test_circles():
                        np.pi*u.deg**2, rtol=1.e-3))
 
 
+def test_stcs():
+    """
+    Test stripping values from STC-S specified strings
+    """
+    stcs = """Union ICRS ( Polygon 239.807341 -18.296691 239.803564 -18.300277 239.799786 -18.296691 239.803563
+    -18.293105 Polygon 239.797826 -18.295944 239.794049 -18.299530 239.790272 -18.295944 239.794049
+    -18.292358)"""
+    
+    sr = SRegion(stcs, verbose=False)
+    
+    assert(len(sr.xy) == 2)
+    assert(np.allclose(sr.area, 2.709e-5, rtol=0.01))
+
+
 def test_whitespace():
     """
     """


### PR DESCRIPTION
Parse a string like

```python
>>> import sregion
>>> sr = sregion.SRegion("""Union ICRS ( Polygon 239.807341 -18.296691 239.803564 -18.300277 239.799786 -18.296691 239.803563
-18.293105 Polygon 239.797826 -18.295944 239.794049 -18.299530 239.790272 -18.295944 239.794049
-18.292358)""")
>>> print(sr.xy)
[array([[239.807341, -18.296691],
        [239.803564, -18.300277],
        [239.799786, -18.296691],
        [239.803563, -18.293105]]),
 array([[239.797826, -18.295944],
        [239.794049, -18.29953 ],
        [239.790272, -18.295944],
        [239.794049, -18.292358]])]


```

The `Union ICRS` prefix is simply stripped from the string and the `SRegion` object is the combination of the two polygons.  Nothing is done for sophisticated "region math" with regions, intersections, differences, etc.

