### PR TITLE
Add function to compute a concave hull of a list of points

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ install_requires =
     numpy
     astropy
     shapely>=2.0
+    scipy
     matplotlib
     
 [options.extras_require]

--- a/sregion/tests/test_utils.py
+++ b/sregion/tests/test_utils.py
@@ -1,0 +1,70 @@
+def test_concave_hull():
+    """
+    Test concave hull function
+    """
+    import numpy as np
+
+    from ..sregion import SRegion
+    from ..utils import concave_hull
+
+    # Demo concave polygon
+    xy = np.array(
+        [
+            [-0.05340819, 0.01697288],
+            [0.00633657, 0.08214911],
+            [0.07965975, -0.01697297],
+            [0.01991492, -0.00746813],
+            [0.00090514, -0.03734045],
+            [-0.05340819, -0.03734045],
+        ]
+    )
+
+    nominal_area = 34.26
+    xy[:, 0] += 10
+
+    sr = SRegion(xy, wrap=True)
+
+    # Random points within the test polygon
+    np.random.seed(1)
+    rnd = np.random.rand(2000, 2)
+
+    mi, ma = xy.min(axis=0), xy.max(axis=0)
+    si = ma - mi
+    rnd = rnd * si + mi
+
+    inside = sr.path[0].contains_points(rnd)
+    rnd = rnd[inside, :]
+
+    assert np.allclose(
+        [area.value for area in sr.sky_area()], nominal_area, rtol=1.0e-2
+    )
+
+    # Test that get the same answer at different locations on the sky
+    for ra in [45, 150]:
+        for dec in [-80, -10, 0, 30, 50]:
+            cosd = np.cos(dec / 180 * np.pi)
+
+            xy_i = xy / np.array([cosd, 1.0]) + np.array([ra, dec])
+            sr_i = SRegion(xy_i, wrap=True)
+
+            assert np.allclose(
+                [area.value for area in sr_i.sky_area()], nominal_area, rtol=1.0e-2
+            )
+
+            rnd_i = rnd / np.array([cosd, 1.0]) + np.array([ra, dec])
+
+            hull_i, _alpha = concave_hull(
+                rnd_i,
+                alpha=0.08,
+                sky=True,
+                ref_density=250,
+                scale_power=0.5,
+            )
+
+            print(ra, dec, hull_i.sky_area()[0], sr_i.sky_area()[0], nominal_area)
+
+            assert hull_i.sky_area()[0] < sr_i.sky_area()[0]
+
+            assert np.allclose(
+                [area.value for area in hull_i.sky_area()], nominal_area, rtol=5.0e-2
+            )

--- a/sregion/utils.py
+++ b/sregion/utils.py
@@ -1,0 +1,161 @@
+"""
+Utilities
+"""
+
+import numpy as np
+from .sregion import SRegion
+
+
+def concave_hull(
+    points, alpha=0.08, sky=True, ref_density=250, scale_power=0.5, **kwargs
+):
+    """
+    Compute the "alpha shape" (concave hull) of a set of points.
+
+    Adapted from
+    https://gist.github.com/jclosure/d93f39a6c7b1f24f8b92252800182889
+    by GitHub user @jclosure
+
+    Parameters
+    ----------
+    points : (N, 2) array
+        Point list
+
+    alpha : float
+        Smoothing parameter
+
+    sky : bool
+        Treat ``points`` as sky coordinates in decimal degrees
+
+    ref_density : float, None
+        Reference sky surface density (N per square arcmin).
+        If provided, scale the input ``alpha`` by the surface density of ``points``
+        relative to ``ref_density``.
+
+    scale_power : float
+        Power on the relative surface density
+
+    Returns
+    -------
+    output_hull : `~sregion.sregion.SRegion`
+        Concave hull of the input ``points`` array
+
+    scale_alpha : float
+        Smoothing parameter used, perhaps rescaled
+
+    """
+    from shapely.ops import cascaded_union, unary_union, polygonize
+    from shapely import geometry
+    from scipy.spatial import Delaunay, ConvexHull
+
+    if points.shape[0] == 2:
+        points = points.T
+
+    if len(points) < 4:
+        # When you have a triangle, there is no sense in computing an alpha
+        # shape.
+        return geometry.MultiPoint(list(points)).convex_hull
+
+    def add_edge(edges, edge_points, coords, i, j):
+        """Add a line between the i-th and j-th points, if not in the list already"""
+        if (i, j) in edges or (j, i) in edges:
+            # already added
+            return
+        edges.add((i, j))
+        edge_points.append(coords[[i, j]])
+
+    center = np.median(points, axis=0)
+    cosd = np.array([np.cos(center[1] / 180 * np.pi), 1.0]) if sky else np.array([1, 1])
+
+    if (ref_density is not None) & (sky):
+        hull = ConvexHull(points)
+        sr = SRegion(points[hull.vertices, :])
+        scale_alpha = (
+            alpha
+            * (ref_density / (len(points) / sr.sky_area()[0].value)) ** scale_power
+        )
+    else:
+        scale_alpha = alpha
+
+    if sky:
+        cosd *= 60
+
+    coords = points - center
+    coords *= cosd
+
+    tri = Delaunay(coords)
+    edges = set()
+    edge_points = []
+
+    # loop over triangles:
+    # ia, ib, ic = indices of corner points of the triangle
+    for ia, ib, ic in tri.simplices:
+        pa = coords[ia]
+        pb = coords[ib]
+        pc = coords[ic]
+
+        # Lengths of sides of triangle
+        a = np.sqrt((pa[0] - pb[0]) ** 2 + (pa[1] - pb[1]) ** 2)
+        b = np.sqrt((pb[0] - pc[0]) ** 2 + (pb[1] - pc[1]) ** 2)
+        c = np.sqrt((pc[0] - pa[0]) ** 2 + (pc[1] - pa[1]) ** 2)
+
+        # Semiperimeter of triangle
+        s = (a + b + c) / 2.0
+
+        # Area of triangle by Heron's formula
+        area = np.sqrt(s * (s - a) * (s - b) * (s - c))
+        circum_r = a * b * c / (4.0 * area)
+        radius = np.sqrt(area / np.pi)
+
+        # Here's the radius filter.
+        # print circum_r
+        # if circum_r < 1.0/alpha:
+        if circum_r < scale_alpha:
+            add_edge(edges, edge_points, coords, ia, ib)
+            add_edge(edges, edge_points, coords, ib, ic)
+            add_edge(edges, edge_points, coords, ic, ia)
+
+    edge_points = [p / cosd + center for p in edge_points]
+
+    m = geometry.MultiLineString(edge_points)
+    triangles = list(polygonize(m))
+    output_hull = SRegion(unary_union(triangles))
+
+    return output_hull, scale_alpha
+
+
+def get_sky_footprint(ra, dec, make_figure=False, **kwargs):
+    """
+    Get the footprint of a list of sky coordinates
+
+    Parameters
+    ----------
+    ra, dec : array-like
+        Sky coordinates, decimal degrees
+
+    make_figure : bool
+        Make a diagnostic figure
+
+    Returns
+    -------
+    catalog_hull : `~sregion.sregion.SRegion`
+        Footprint
+
+    fig : `~matplotlib.Figure`
+        Figure object
+
+    """
+    import matplotlib.pyplot as plt
+
+    points = np.array([ra, dec]).T
+    catalog_hull, scale_alpha = concave_hull(points, **kwargs)
+
+    if make_figure:
+        fig, ax = plt.subplots(1, 1, figsize=(5, 5))
+        ax.scatter(*points.T, color="0.5", alpha=0.05, marker=".")
+        catalog_hull.add_patch_to_axis(ax, fc="tomato", ec="None", alpha=0.2)
+        catalog_hull.add_patch_to_axis(ax, fc="None", ec="tomato", alpha=0.5)
+    else:
+        fig = None
+
+    return catalog_hull, fig


### PR DESCRIPTION
Add functionality to, e.g., estimate the footprint of an array of sky coordinates.  Uses the clever code from https://gist.github.com/jclosure/d93f39a6c7b1f24f8b92252800182889 to compute the concave hull of a list of points.

```python
import numpy as np
import matplotlib.pyplot as plt
from sregion import SRegion
import sregion.utils

# Demo catalog of points within a concave polygon

xy = np.array(
    [
        [-0.05340819, 0.01697288],
        [0.00633657, 0.08214911],
        [0.07965975, -0.01697297],
        [0.01991492, -0.00746813],
        [0.00090514, -0.03734045],
        [-0.05340819, -0.03734045],
    ]
)

nominal_area = 34.26
xy[:, 0] += 10

sr = SRegion(xy, wrap=True)

# Random points within the test polygon
np.random.seed(1)
rnd = np.random.rand(2000, 2)

mi, ma = xy.min(axis=0), xy.max(axis=0)
si = ma - mi
rnd = rnd * si + mi

inside = sr.path[0].contains_points(rnd)
rnd = rnd[inside, :]

fig, axes = plt.subplots(1,3,figsize=(12,4), sharex=True, sharey=True)

for s, ax in zip([0.05, 0.08, 0.2], axes):
    ax.scatter(*rnd.T, color='k', alpha=0.1)
    
    sr.add_patch_to_axis(ax, fc='None', ec='magenta', label=f'Input footprint, area={sr.sky_area()[0]:.1f}')

    hull_i, _scale_smooth = sregion.utils.concave_hull(rnd, smooth=s)
    total_area = np.sum([a.value for a in hull_i.sky_area()])
    
    label = f'concave_hull, smooth = {s}, area={total_area:.1f}'
    ax.plot(*hull_i.xy[0].T, color='tomato', label=label, alpha=0.5)
    hull_i.add_patch_to_axis(ax, fc='tomato', ec='None', alpha=0.5) #, label=label)

    ax.legend()
    ax.grid()
    
ax.set_xlim(*ax.get_xlim()[::-1])

fig.tight_layout(pad=1)
```
![sregion_hull](https://github.com/user-attachments/assets/74f09aaf-c258-4a5b-85b8-405ae95ab819)
