### PR TITLE
Update to get setuptools compliance

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,5 +40,5 @@ exclude = extern,sphinx,*parsetab.py,astropy_helpers,ah_bootstrap.py,conftest.py
 exclude = extern,sphinx,*parsetab.py,astropy_helpers,ah_bootstrap.py,conftest.py,docs/conf.py,setup.py
 
 [entry_points]
-astropy-package-template-example = packagename.example_mod:main
+astropy_package_template_example = packagename.example_mod:main
 


### PR DESCRIPTION
sregion stopped installing correctly with pip. This seems to fix it. 