### PR TITLE
Implement padding

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ matplotlib
 astropy
 shapely
 descartes
+scipy

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ install_requires =
     shapely>=2.0
     scipy
     matplotlib
+    scipy
     
 [options.extras_require]
 test =

--- a/sregion/tests/test_sregion.py
+++ b/sregion/tests/test_sregion.py
@@ -280,3 +280,36 @@ def test_draw_patch():
     circ.add_patch_to_axis(ax, fc="r", alpha=0.5)
 
     plt.close("all")
+
+
+def test_convex_hull():
+
+    x = np.array([0, 0, 1, 1, 0.5])
+    y = np.array([0, 1, 1, 0, 0.5])
+
+    srh = SRegion(np.array([x, y]).T, get_convex_hull=True)
+    assert srh.xy[0].ndim == 2
+    assert srh.area[0] == 1.0
+
+
+def test_padding():
+
+    x = np.array([0, 0, 1, 1])
+    y = np.array([0, 1, 1, 0])
+
+    sr = SRegion(np.array([x, y]).T, pad=2)
+    assert sr.area[0] == 4.0
+
+    sr = SRegion(np.array([x, y]).T)
+    sr.pad(scale=2, in_place=True)
+    assert sr.area[0] == 4.0
+
+    sr = SRegion(np.array([x, y]).T, wrap=False)
+    sr2 = sr.pad(scale=2., in_place=False)
+    assert sr2.area[0] == 4.0
+    assert np.allclose(sr2.centroid, 0.5)
+
+    sr = SRegion(np.array([x, y]).T, wrap=False)
+    sr2 = sr.pad(scale=2., center=[0,0], in_place=False)
+    assert sr2.area[0] == 4.0
+    assert np.allclose(sr2.centroid, 1.0)


### PR DESCRIPTION
Implement `SRegion.pad` method for expanding and contracting a region.

```python
x = np.array([0, 0, 1, 1])
y = np.array([0, 1, 1, 0])

#####
# On initialization
sr = SRegion(np.array([x, y]).T, pad=2)
print(sr.xy[0])
# [[-0.5, -0.5], [-0.5, 1.5], [1.5, 1.5], [1.5, -0.5]]

#####
# Update existing object
sr = SRegion(np.array([x, y]).T)
print(sr.xy[0])
# [[0.0, 0.0], [0.0, 1.0], [1.0, 1.0], [1.0, 0.0]]

sr.pad(scale=2, in_place=True)
print(sr.xy[0])
# [[-0.5, -0.5], [-0.5, 1.5], [1.5, 1.5], [1.5, -0.5]]

#####
# Create a new object
sr = SRegion(np.array([x, y]).T, wrap=False)
sr2 = sr.pad(scale=2., in_place=False)
print(sr2.xy[0])
# [[-0.5, -0.5], [-0.5, 1.5], [1.5, 1.5], [1.5, -0.5]]

#####
# Expand from a center other than `SRegion.centroid`
sr = SRegion(np.array([x, y]).T, wrap=False)
sr2 = sr.pad(scale=2., center=[0,0], in_place=False)
print(sr2.xy[0])
# [[0.0, 0.0], [0.0, 2.0], [2.0, 2.0], [2.0, 0.0]]

#####
# The method also implements computing a convex hull from the input upon initialization
x = np.array([0, 0, 1, 1, 0.5])
y = np.array([0, 1, 1, 0, 0.5])

srh = SRegion(np.array([x, y]).T, get_convex_hull=True)
print(srh.xy[0])
# [[0.0, 1.0], [0.0, 0.0], [1.0, 0.0], [1.0, 1.0]]
```